### PR TITLE
Check page visibility api when sending webkitNotifications

### DIFF
--- a/chat/assets/util.coffee
+++ b/chat/assets/util.coffee
@@ -120,7 +120,7 @@ window.Util =
   # 1) document.hasFocus
   # 2) !document.hidden
   pageIsVisible: ->
-    document.hasFocus() and (document.hidden ? document.webkitHidden ? document.mozHidden)
+    document.hasFocus() and not (document.hidden ? document.webkitHidden ? document.mozHidden)
 
   createNotification: (icon, title, msg) ->
     shouldNotify = webkitNotifications? and


### PR DESCRIPTION
Check page visibility api when sending webkitNotifications. You may have some comments on CS style. I'm happy to change any style stuff you might have. Also wrote it with cross-browser compatibility in mind, because I'm interested in playing around with playing around with [Firefox notifications](https://developer.mozilla.org/en-US/docs/WebAPI/Using_Web_Notifications) and seeing if I can get those working.
